### PR TITLE
Make sure the logical value is of length 1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: readxlsb
 Type: Package
 Title: Read 'Excel' Binary (.xlsb) Workbooks
-Version: 0.1.61
+Version: 0.1.62
 Date: 2023-03-03
 Authors@R: person("Michael", "Allen", role = c("aut", "cre"), email = "michael@velofrog.com")
 Depends: R (>= 3.3.0)

--- a/R/read_xlsb.R
+++ b/R/read_xlsb.R
@@ -104,7 +104,7 @@ read_xlsb = function(path, sheet = NULL, range = NULL, col_names = TRUE, col_typ
   }
   
   ## If range is not specified, but sheet is, then set range to the entire sheet
-  if ((is.null(range) || is.na(range)) && (!is.null(sheet) && !is.na(sheet))) {
+  if ((is.null(range) || any(is.na(range))) && (!is.null(sheet) && !is.na(sheet))) {
     range = cellranger::cell_limits(ul = c(1, 1), lr = c(NA, NA), sheet = sheet)
   }
   


### PR DESCRIPTION
For example, `range = cell_cols("C:I")`, `is.null(range) || is.na(range)` will fail in R 4.3.x because `is.na(range)` is of length > 1. Perhaps you want `any(is.na())`.

```r
FALSE || c(TRUE, FALSE, FALSE)
```
```
Error in FALSE || c(TRUE, FALSE, FALSE) : 
  'length = 3' in coercion to 'logical(1)'
```